### PR TITLE
Option for base_url

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,9 @@ help:
 bash:
 	@$(DOCKER) bash
 
+dev: ARGS?=
 dev:
-	@$(DOCKER) python kernel_gateway --KernelGatewayApp.ip='0.0.0.0'
+	$(DOCKER) python kernel_gateway --KernelGatewayApp.ip='0.0.0.0' $(ARGS)
 
 # usage:
 # make test

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ A [JupyterApp](https://github.com/jupyter/jupyter_core/blob/master/jupyter_core/
 * A way to bridge the [Jupyter protocol](http://jupyter-client.readthedocs.org/en/latest/messaging.html) from Websocket to [ZeroMQ](http://zeromq.org/)
 * A shared token authorization scheme
 * CORS headers as options for servicing browser-based clients
+* Ability to set a custom base URL (e.g., for running under tmpnb)
 * A CLI for launching the kernel gateway: `jupyter kernelgateway OPTIONS`
 
 ## What It Lacks


### PR DESCRIPTION
Allow mounting of `/api` resources under a root specified on launch.