### PR TITLE
Option to limit number of kernels allowed

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A [JupyterApp](https://github.com/jupyter/jupyter_core/blob/master/jupyter_core/
 * A shared token authorization scheme
 * CORS headers as options for servicing browser-based clients
 * Ability to set a custom base URL (e.g., for running under tmpnb)
+* Option to limit the number kernel instances a gateway server will launch (e.g., to force scaling at the container level)
 * A CLI for launching the kernel gateway: `jupyter kernelgateway OPTIONS`
 
 ## What It Lacks
@@ -29,7 +30,6 @@ These are in scope, but not yet implemented.
 * PyPI package
 * Ability to prespawn kernels
 * Ability to select a default kernel
-* Ability to limit # of kernels
 * Ability to prepopulate kernel memory from a notebook
 
 ## Alternatives

--- a/kernel_gateway/gatewayapp.py
+++ b/kernel_gateway/gatewayapp.py
@@ -104,6 +104,15 @@ class KernelGatewayApp(JupyterApp):
     def _max_age_default(self):
         return os.getenv(self.max_age_env, '')
 
+    max_kernels_env = 'KG_MAX_KERNELS'
+    max_kernels = Integer(config=True,
+        allow_none=True,
+        help='Limits the number of kernel instances allowed to run by this gateway. (KG_MAX_KERNELS env var)'
+    )
+    def _max_kernels_default(self):
+        val = os.getenv(self.max_kernels_env)
+        return val if val is None else int(val)
+
     def initialize(self, argv=None):
         '''
         Initialize base class, configurable Jupyter instances, the tornado web 
@@ -155,7 +164,8 @@ class KernelGatewayApp(JupyterApp):
             kg_allow_methods=self.allow_methods,
             kg_allow_origin=self.allow_origin,
             kg_expose_headers=self.expose_headers,
-            kg_max_age=self.max_age
+            kg_max_age=self.max_age,
+            kg_max_kernels=self.max_kernels
         )
 
     def init_http_server(self):

--- a/kernel_gateway/services/kernels/handlers.py
+++ b/kernel_gateway/services/kernels/handlers.py
@@ -1,15 +1,36 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
+import tornado
 import notebook.services.kernels.handlers as notebook_handlers
 from ...mixins import TokenAuthorizationMixin, CORSMixin
 
+class MainKernelHandler(TokenAuthorizationMixin, 
+                        CORSMixin, 
+                        notebook_handlers.MainKernelHandler):
+    def post(self):
+        '''
+        Honors the max number of allowed kernels configuration setting. Raises
+        402 (for lack of a better HTTP error code) if at the limit.
+        '''
+        max_kernels = self.settings['kg_max_kernels']
+        if max_kernels is not None:
+            km = self.settings['kernel_manager']
+            kernels = km.list_kernels()
+            if len(kernels) >= max_kernels:
+                raise tornado.web.HTTPError(402, 'Resource Limit')
+        super(MainKernelHandler, self).post()
+
 default_handlers = []
 for path, cls in notebook_handlers.default_handlers:
-    if path.endswith('channels'):
-        # Websocket handler shouldn't have CORS headers
-        bases = (TokenAuthorizationMixin, cls)
-    else: 
-        # Everything else should have CORS and token auth
-        bases = (TokenAuthorizationMixin, CORSMixin, cls)
-    default_handlers.append((path, type(cls.__name__, bases, {})))
+    if cls.__name__ in globals():
+        # Use the same named class from here if it exists
+        default_handlers.append((path, globals()[cls.__name__]))
+    else:
+        # Gen a new type with CORS and token auth
+        if path.endswith('channels'):
+            # Websocket handler shouldn't have CORS headers
+            bases = (TokenAuthorizationMixin, cls)
+        else:
+            bases = (TokenAuthorizationMixin, CORSMixin, cls)
+        default_handlers.append((path, type(cls.__name__, bases, {})))


### PR DESCRIPTION
Limit the number of running kernels allowed by an instance of the gateway. 

Use case: if I'm deploying the gateway within a container and scaling at the container level, I may want to limit to N kernels per container and control total number of kernels at the container level.