### PR TITLE
[Issue 29]: Options to enable HTTP access to kernels

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,9 +31,10 @@ clean:
 	@-find . -name __pycache__ -exec rm -fr {} \;
 
 dev: ARGS?=
+dev: PYARGS?=
 dev:
 	@$(DOCKER) -p 8888:8888 $(IMAGE) \
-		python kernel_gateway --KernelGatewayApp.ip='0.0.0.0' $(ARGS)
+		python $(PYARGS) kernel_gateway --KernelGatewayApp.ip='0.0.0.0' $(ARGS)
 
 install:
 	$(DOCKER) $(IMAGE) pip install --no-use-wheel dist/*.tar.gz

--- a/etc/api_examples/api_intro.ipynb
+++ b/etc/api_examples/api_intro.ipynb
@@ -1,0 +1,438 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# API Creation \n",
+    "This notebook is a sample of how to author a REST API in the notebook environment."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import json"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "hello_message = 'hello {}'\n",
+    "people = ['Corey', 'Nitin', 'Pete']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Hello"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "hello world\n"
+     ]
+    }
+   ],
+   "source": [
+    "# GET /hello\n",
+    "print(hello_message.format('world'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "REQUEST = json.dumps({\n",
+    "    'args': { \n",
+    "        'person' : people\n",
+    "    }\n",
+    "})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "hello Corey\n"
+     ]
+    }
+   ],
+   "source": [
+    "# GET /hello/person\n",
+    "req = json.loads(REQUEST)\n",
+    "hello_person = req['args']['person'][0]\n",
+    "print(hello_message.format(hello_person))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "REQUEST = json.dumps({\n",
+    "    'args': { \n",
+    "        'person' : people\n",
+    "    }\n",
+    "})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "hello Corey, Nitin, Pete\n"
+     ]
+    }
+   ],
+   "source": [
+    "# GET /hello/persons\n",
+    "req = json.loads(REQUEST)\n",
+    "hello_persons = req['args']['person']\n",
+    "print(hello_message.format(', '.join(hello_persons)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "hello Corey, Nitin, Pete\n"
+     ]
+    }
+   ],
+   "source": [
+    "# GET /hello/people\n",
+    "hello_people = people\n",
+    "print(hello_message.format(', '.join(hello_people)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "REQUEST = json.dumps({\n",
+    "    'path' : {\n",
+    "        'person' : 'test_person'\n",
+    "    }\n",
+    "})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "hello test_person\n"
+     ]
+    }
+   ],
+   "source": [
+    "# GET /hello/:person\n",
+    "req = json.loads(REQUEST)\n",
+    "print(hello_message.format(req['path']['person']))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Messages"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "hello {}\n"
+     ]
+    }
+   ],
+   "source": [
+    "# GET /message\n",
+    "print(hello_message)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "REQUEST = json.dumps({\n",
+    "    'body' : 'test value'\n",
+    "})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "test value\n"
+     ]
+    }
+   ],
+   "source": [
+    "# PUT /message\n",
+    "req = json.loads(REQUEST)\n",
+    "hello_message = req['body']\n",
+    "print(hello_message)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## People"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['Corey', 'Nitin', 'Pete']\n"
+     ]
+    }
+   ],
+   "source": [
+    "# GET /people\n",
+    "print(people)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "REQUEST = json.dumps({\n",
+    "    'body' : ['Rick', 'Maggie', 'Glenn', 'Carol', 'Daryl']\n",
+    "})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['Rick', 'Maggie', 'Glenn', 'Carol', 'Daryl']\n"
+     ]
+    }
+   ],
+   "source": [
+    "# POST /people\n",
+    "req = json.loads(REQUEST)\n",
+    "people = req['body']\n",
+    "print(people)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "REQUEST = json.dumps({\n",
+    "    'body' : 'Michonne'\n",
+    "})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['Rick', 'Maggie', 'Glenn', 'Carol', 'Daryl', 'Michonne']\n"
+     ]
+    }
+   ],
+   "source": [
+    "# PUT /people\n",
+    "req = json.loads(REQUEST)\n",
+    "people.append(req['body'])\n",
+    "print(people)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "REQUEST = json.dumps({\n",
+    "    'path' : {\n",
+    "        'index' : 1\n",
+    "    }\n",
+    "})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['Rick', 'Glenn', 'Carol', 'Daryl', 'Michonne']\n"
+     ]
+    }
+   ],
+   "source": [
+    "# DELETE /people/:index\n",
+    "req = json.loads(REQUEST)\n",
+    "people.remove(people[int(req['path']['index'])])\n",
+    "print(people)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Error"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "ename": "SyntaxError",
+     "evalue": "invalid syntax (<ipython-input-24-f38d0efb0223>, line 2)",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[1;36m  File \u001b[1;32m\"<ipython-input-24-f38d0efb0223>\"\u001b[1;36m, line \u001b[1;32m2\u001b[0m\n\u001b[1;33m    this cell should print an error in the reponse\u001b[0m\n\u001b[1;37m            ^\u001b[0m\n\u001b[1;31mSyntaxError\u001b[0m\u001b[1;31m:\u001b[0m invalid syntax\n"
+     ]
+    }
+   ],
+   "source": [
+    "# GET /error\n",
+    "this cell should print an error in the reponse"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.4.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/etc/api_examples/endpoint_ordering.ipynb
+++ b/etc/api_examples/endpoint_ordering.ipynb
@@ -1,0 +1,120 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# API Endpoint Registration\n",
+    "The cells below test ordering api endpoints. They should appear in the order they are listed below (with some out of order in areas where there are ties). The ordering for handlers is as follows:\n",
+    "  1. Constant endpoints\n",
+    "  1. Endpoints with path params\n",
+    "    1. Ordered in descending order by the path index of the first path param"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# GET /test/test/test/test\n",
+    "print('path param index test 1')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# GET /test/test/test/:id\n",
+    "print('path param index test 2')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# GET /test/test/:id\n",
+    "print('path param index test 3')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# GET /t/t/:id\n",
+    "print('path param index test 3')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# GET /test/:id\n",
+    "print('path param index test 4')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# GET /t/:id\n",
+    "print('path param index test 4')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# GET /:id\n",
+    "print('path param index test 5')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.4.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/etc/api_examples/scotch_api.ipynb
+++ b/etc/api_examples/scotch_api.ipynb
@@ -1,0 +1,287 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "urth": {
+     "dashboard": {
+      "layout": {
+       "col": 0,
+       "height": 2,
+       "row": 0,
+       "width": 12
+      }
+     }
+    },
+    "urth_section": {
+     "id": "1",
+     "layout": "vertical"
+    }
+   },
+   "source": [
+    "# Got Scotch API?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "urth": {
+     "dashboard": {
+      "hidden": true
+     }
+    }
+   },
+   "source": [
+    "This notebook is meant to demonstrate the transformation of an annotated notebook into a HTTP API using the Jupyter kernel gateway. The result is a simple scotch recommendation engine.\n",
+    "\n",
+    "The original scotch data is from [https://www.mathstat.strath.ac.uk/outreach/nessie/nessie_whisky.html](https://www.mathstat.strath.ac.uk/outreach/nessie/nessie_whisky.html)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false,
+    "urth": {
+     "dashboard": {
+      "hidden": true
+     }
+    },
+    "urth_section": {}
+   },
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import pickle\n",
+    "import requests\n",
+    "import json"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "urth": {
+     "dashboard": {
+      "hidden": true
+     }
+    },
+    "urth_section": {}
+   },
+   "source": [
+    "## Data\n",
+    "\n",
+    "We read the scotch data from a public Box URL to make this notebook more portable. This is acceptable for small, public, demo data which is what we have here."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "features_uri = 'https://ibm.box.com/shared/static/2vntdqbozf9lzmukkeoq1lfi2pcb00j1.dataframe' \n",
+    "sim_uri = 'https://ibm.box.com/shared/static/54kzs5zquv0vjycemjckjbh0n00e7m5t.dataframe'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": false,
+    "urth": {
+     "dashboard": {
+      "hidden": true
+     }
+    }
+   },
+   "outputs": [],
+   "source": [
+    "resp = requests.get(features_uri)\n",
+    "resp.raise_for_status()\n",
+    "features_df = pickle.loads(resp.content)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "resp = requests.get(sim_uri)\n",
+    "resp.raise_for_status()\n",
+    "sim_df = pickle.loads(resp.content)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "urth": {
+     "dashboard": {
+      "hidden": true
+     }
+    }
+   },
+   "source": [
+    "Drop the cluster column. Don't need it here."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false,
+    "urth": {
+     "dashboard": {
+      "hidden": true
+     }
+    }
+   },
+   "outputs": [],
+   "source": [
+    "features_df = features_df.drop('cluster', axis=1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## API\n",
+    "\n",
+    "We need to define a global `REQUEST` JSON string that will be replaced on each invocation of the API. We only care about path parameters and query string arguments, so we default those to blank here for development."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "REQUEST = json.dumps({\n",
+    "    'path' : {},\n",
+    "    'args' : {}\n",
+    "})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Provide a way to get the names of all the scotches known by the model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\"names\": [\"Aberfeldy\", \"Aberlour\", \"AnCnoc\", \"Ardbeg\", \"Ardmore\", \"ArranIsleOf\", \"Auchentoshan\", \"Auchroisk\", \"Aultmore\", \"Balblair\", \"Balmenach\", \"Belvenie\", \"BenNevis\", \"Benriach\", \"Benrinnes\", \"Benromach\", \"Bladnoch\", \"BlairAthol\", \"Bowmore\", \"Bruichladdich\", \"Bunnahabhain\", \"Caol Ila\", \"Cardhu\", \"Clynelish\", \"Craigallechie\", \"Craigganmore\", \"Dailuaine\", \"Dalmore\", \"Dalwhinnie\", \"Deanston\", \"Dufftown\", \"Edradour\", \"GlenDeveronMacduff\", \"GlenElgin\", \"GlenGarioch\", \"GlenGrant\", \"GlenKeith\", \"GlenMoray\", \"GlenOrd\", \"GlenScotia\", \"GlenSpey\", \"Glenallachie\", \"Glendronach\", \"Glendullan\", \"Glenfarclas\", \"Glenfiddich\", \"Glengoyne\", \"Glenkinchie\", \"Glenlivet\", \"Glenlossie\", \"Glenmorangie\", \"Glenrothes\", \"Glenturret\", \"Highland Park\", \"Inchgower\", \"Isle of Jura\", \"Knochando\", \"Lagavulin\", \"Laphroig\", \"Linkwood\", \"Loch Lomond\", \"Longmorn\", \"Macallan\", \"Mannochmore\", \"Miltonduff\", \"Mortlach\", \"Oban\", \"OldFettercairn\", \"OldPulteney\", \"RoyalBrackla\", \"RoyalLochnagar\", \"Scapa\", \"Speyburn\", \"Speyside\", \"Springbank\", \"Strathisla\", \"Strathmill\", \"Talisker\", \"Tamdhu\", \"Tamnavulin\", \"Teaninich\", \"Tobermory\", \"Tomatin\", \"Tomintoul\", \"Tormore\", \"Tullibardine\"]}\n"
+     ]
+    }
+   ],
+   "source": [
+    "# GET /scotches\n",
+    "names = sim_df.columns.tolist()\n",
+    "print(json.dumps(dict(names=names)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let clients query for features about a specific scotch given its name."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# GET /scotches/:scotch\n",
+    "request = json.loads(REQUEST)\n",
+    "name = request['path'].get('scotch', 'Talisker')\n",
+    "features = features_df.loc[name]\n",
+    "# can't use to_dict because it retains numpy types which blow up when we json.dumps\n",
+    "print('{\"features\":%s}' % features.to_json())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let clients request a set of scotches similar to the one named. Let clients specify how many results they wish to receive (`count`) and if they want all of the raw feature data included in the result or not (`include_features`)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# GET /scotches/:scotch/similar\n",
+    "request = json.loads(REQUEST)\n",
+    "name = request['path'].get('scotch', 'Talisker')\n",
+    "count = request['args'].get('count', 5)\n",
+    "inc_features = request['args'].get('include_features', True)\n",
+    "\n",
+    "similar = sim_df[name].order(ascending=False)\n",
+    "similar.name = 'Similarity'\n",
+    "df = pd.DataFrame(similar).ix[1:count+1]\n",
+    "\n",
+    "if inc_features:\n",
+    "    df = df.join(features_df)\n",
+    "    \n",
+    "df = df.reset_index().rename(columns={'Distillery': 'Name'})\n",
+    "result = {\n",
+    "    'recommendations' : [row[1].to_dict() for row in df.iterrows()],\n",
+    "    'for': name\n",
+    "}\n",
+    "print(json.dumps(result))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.4.3"
+  },
+  "urth": {
+   "dashboard": {
+    "cellMargin": 10,
+    "defaultCellHeight": 20,
+    "maxColumns": 12
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/kernel_gateway/services/kernels/manager.py
+++ b/kernel_gateway/services/kernels/manager.py
@@ -2,6 +2,8 @@
 # Distributed under the terms of the Modified BSD License.
 
 from notebook.services.kernels.kernelmanager import MappingKernelManager
+import re
+import sys
 
 class SeedingMappingKernelManager(MappingKernelManager):
     @property
@@ -62,4 +64,109 @@ class SeedingMappingKernelManager(MappingKernelManager):
                         # Shutdown the kernel
                         self.shutdown_kernel(kernel_id)
                         raise RuntimeError('Error seeding kernel memory')
+        return kernel_id
+
+class APIMappingKernelManager(MappingKernelManager):
+    def endpoints(self):
+        '''
+        Return a list of tuples containing the method+URI and the cell source
+        '''
+        endpoints = {}
+        for cell_source in self._source:
+            matched = self.api_indicator.match(cell_source)
+            if matched is not None:
+                uri = matched.group(2)
+                verb = matched.group(1)
+                if uri not in endpoints:
+                    endpoints[uri] = {}
+                if verb not in endpoints[uri]:
+                    endpoints[uri][verb] = cell_source
+
+        return endpoints
+
+    def sorted_endpoints(self):
+        '''Sorts the endpoints dictionary to be a list of endpoint string in order
+        from most specific to least specific.
+        '''
+        return sorted(self.endpoints(), key=self._first_path_param_index, reverse=True)
+
+    def _first_path_param_index(self, endpoint):
+        '''Returns the index to the first path parameter for the endpoint. The
+        index is not the string index, but rather where it is within the path.
+        For example:
+            first_path_param_index('/foo/:bar') # returns 1
+            first_path_param_index('/foo/quo/:bar') # return 2
+            first_path_param_index('/foo/quo/bar') # return sys.maxsize
+        '''
+        index = sys.maxsize
+        if endpoint.find(':') >= 0:
+            index = endpoint.count('/', 0, endpoint.find(':')) - 1
+        return index
+
+    @property
+    def kernelspec(self):
+        '''
+        Gets the kernel spec name required to run the notebook. Returns
+        None if no notebook exists.
+        '''
+        if hasattr(self, '_kernelspec'):
+            return self._kernelspec
+
+        if self.notebook:
+            self._kernelspec = self.notebook['metadata']['kernelspec']['name']
+        else:
+            self._kernelspec = None
+
+        return self._kernelspec
+
+    @property
+    def source(self):
+        '''
+        Gets the code source of the notebook in cell order. Returns None if no
+        notebook exists.
+        '''
+        if hasattr(self, '_source'):
+            return self._source
+
+        if self.notebook:
+            self._source = [
+                cell['source'] for cell in self.notebook.cells
+                if cell['cell_type'] == 'code'
+            ]
+        else:
+            self._source = None
+
+        return self._source
+
+    def start_kernel(self, *args, **kwargs):
+        '''
+        Starts a kernel and then optionally executes a list of code cells on it
+        before returning its ID.
+        '''
+        if self.kernelspec == 'r':
+            self.api_indicator = re.compile('{}\s+([A-Z]+)\s+(\/.*)+'.format('#'))
+        elif self.kernelspec == 'scala':
+            self.api_indicator = re.compile('{}\s+([A-Z]+)\s+(\/.*)+'.format('//'))
+        else:
+            self.api_indicator = re.compile('{}\s+([A-Z]+)\s+(\/.*)+'.format('#'))
+
+        kernel_id = super(MappingKernelManager, self).start_kernel(kernel_name=self.kernelspec, *args, **kwargs)
+        if kernel_id and self.source is not None:
+            # Only run source if the kernel matches
+            kernel = self.get_kernel(kernel_id)
+            if kernel.kernel_name == self.kernelspec:
+                # Connect to the kernel and pump in the content of the notebook
+                # before returning the kernel ID to the requesting client
+                client = kernel.client()
+                for code in self.source:
+                        # Execute every non-API code cell and wait for each to succeed or fail
+                    if self.api_indicator.match(code) is None:
+                        client.execute(code)
+                        msg = client.shell_channel.get_msg(block=True)
+                        if msg['content']['status'] != 'ok':
+                            # Shutdown the kernel
+                            self.shutdown_kernel(kernel_id)
+                            raise RuntimeError('Error initializing kernel memory', code)
+                client.start_channels()
+                client.wait_for_ready()
         return kernel_id

--- a/kernel_gateway/services/notebooks/handlers.py
+++ b/kernel_gateway/services/notebooks/handlers.py
@@ -1,0 +1,102 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+import tornado.web
+from tornado.log import access_log
+import json
+from .request_utils import *
+try:
+    from queue import Empty
+except ImportError:
+    from Queue import Empty
+
+class NotebookAPIHandler(tornado.web.RequestHandler):
+    get_source = None
+    put_source = None
+    post_source = None
+    delete_source = None
+    kernel_client = None
+    execution_timeout = 5
+    kernel_name = ''
+    
+    def initialize(self, sources, kernel_client, kernel_name):
+        self.kernel_client = kernel_client
+        if 'GET' in sources:
+            self.get_source = sources['GET']
+        if 'POST' in sources:
+            self.post_source = sources['POST']
+        if 'PUT' in sources:
+            self.put_source = sources['PUT']
+        if 'DELETE' in sources:
+            self.delete_source = sources['DELETE']
+        self.kernel_name = kernel_name
+
+    def _send_code(self, code, block=True):
+        # execute the code and return the result and HTTP status code
+        self.kernel_client.execute(code)
+        result_found = False
+        iopub_message = None
+        result = None
+        status = 200
+        try:
+            while(result is None):
+                iopub_message = self.kernel_client.get_iopub_msg(block=block, timeout=self.execution_timeout)
+                if iopub_message['header']['msg_type'] == 'execute_result':
+                    result = iopub_message['content']['data']
+                elif iopub_message['header']['msg_type'] == 'stream':
+                    result = iopub_message['content']['text']
+                elif iopub_message['header']['msg_type'] == 'error':
+                    result = 'Error {}: {} \n'.format(
+                        iopub_message['content']['ename'],
+                        iopub_message['content']['evalue']
+                    )
+                    status = 500
+        except Empty:
+            access_log.debug('Never found execute result')
+            pass
+
+        return result, status
+
+    def _handle_request(self, source_code):
+        if source_code is None:
+            self.set_status(405)
+            self.finish()
+            return
+
+        REQUEST = json.dumps({
+            'body' : parse_body(self.request.body),
+            'args' : parse_args(self.request.arguments),
+            'path' : self.path_kwargs
+        })
+        if self.kernel_name == 'r':
+            request_code = "REQUEST <- '"  + REQUEST + "'"
+        else:
+            request_code = "REQUEST = '"  + REQUEST + "'"
+
+        access_log.debug('Request code for notebook cell is: {}'.format(request_code))
+        # TODO: Need to figure out multil-lang assignment
+        self._send_code(request_code, False)
+        result, status = self._send_code(source_code)
+
+        # TODO: Will we need to add the ability to specify mime types?
+        self.set_header('Content-Type', 'text/plain')
+        if result is not None:
+            self.write(result)
+        self.set_status(status)
+        self.finish()
+
+    def get(self, **kwargs):
+        # execute the get_source
+        self._handle_request(self.get_source)
+    def post(self, **kwargs):
+        # execute the post_source
+        self._handle_request(self.post_source)
+
+    def put(self, **kwargs):
+        # execute the put_source
+        print('in put method')
+        self._handle_request(self.put_source)
+
+    def delete(self, **kwargs):
+        print('in delete method')
+        # execute the delete_source
+        self._handle_request(self.delete_source)

--- a/kernel_gateway/services/notebooks/request_utils.py
+++ b/kernel_gateway/services/notebooks/request_utils.py
@@ -1,0 +1,35 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+import json
+import re
+
+_named_param_regex = re.compile('(:([^/]*))')
+
+def parameterize_path(path):
+    matches = re.findall(_named_param_regex, path)
+    for match in matches:
+        path = path.replace(match[0], '(?P<{}>[^\/]+)'.format(match[1]))
+    return path
+
+def parse_body(body):
+    '''Converts body into a proper JSON string. body is expected to be a UTF-8
+    byte string. If body is the empty string or None, the empty string will be
+    returned.
+    '''
+    body = body.decode(encoding='UTF-8')
+    if body is not None and body is not '':
+        return json.loads(body)
+    else:
+        return ''
+
+def parse_args(args):
+    '''Converts args into a proper JSON string. args is expected to be a dictionary
+    where the values are arrays of UTF-8 byte strings.
+    '''
+    ARGS = {}
+    for key in args:
+        ARGS[key] = []
+        for value in args[key]:
+            ARGS[key].append(value.decode(encoding='UTF-8'))
+    return ARGS

--- a/kernel_gateway/tests/test_gatewayapp.py
+++ b/kernel_gateway/tests/test_gatewayapp.py
@@ -472,7 +472,7 @@ class TestSeedGatewayApp(TestGatewayAppBase):
 
     @gen_test
     def test_seed(self):
-        '''Kernel should have variables preseeded from notebook.'''
+        '''Kernel should have variables preseeded from notebook. Failures may be the result of networking problems.'''
         ws = yield self.spawn_kernel()
 
         # Print the encoded "zen of python" string, the kernel should have


### PR DESCRIPTION
   Refactored with changes from @Lull3rSkat3r and @parente:
   * Use kernel client library to wait for the kernel to start,
       draining shell output when executing non-API cells
   * Added path params for access from API functions.
   * Fixed encoding issue with args parsing.
   * Added scotch notebook example.
   * Add parsing of query parameters.
   * Can access request body from cells.
   * Body assignment and API cell indicator respect notebook kernel spec.

(c) Copyright IBM Corp. 2015