### PR TITLE
[Issue 43]: Fixed regex for path parameter extraction and trim endpoints

### DIFF
--- a/kernel_gateway/services/kernels/manager.py
+++ b/kernel_gateway/services/kernels/manager.py
@@ -34,7 +34,7 @@ class SeedingMappingKernelManager(MappingKernelManager):
         for cell_source in self.seed_source:
             matched = self.api_indicator.match(cell_source)
             if matched is not None:
-                uri = matched.group(2)
+                uri = matched.group(2).strip()
                 verb = matched.group(1)
                 if uri not in endpoints:
                     endpoints[uri] = {}

--- a/kernel_gateway/services/notebooks/request_utils.py
+++ b/kernel_gateway/services/notebooks/request_utils.py
@@ -4,13 +4,13 @@
 import json
 import re
 
-_named_param_regex = re.compile('(:([^/]*))')
+_named_param_regex = re.compile('(:([^/\s]*))')
 
 def parameterize_path(path):
     matches = re.findall(_named_param_regex, path)
     for match in matches:
         path = path.replace(match[0], '(?P<{}>[^\/]+)'.format(match[1]))
-    return path
+    return path.strip()
 
 def parse_body(body):
     '''Converts body into a proper JSON string. body is expected to be a UTF-8

--- a/kernel_gateway/tests/services/notebooks/test_request_utils.py
+++ b/kernel_gateway/tests/services/notebooks/test_request_utils.py
@@ -30,3 +30,9 @@ class TestRequestUtils(unittest.TestCase):
         self.assertEqual(result, '/foo/(?P<bar>[^\/]+)')
         result = parameterize_path('/foo/:bar/baz/:quo')
         self.assertEqual(result, '/foo/(?P<bar>[^\/]+)/baz/(?P<quo>[^\/]+)')
+
+    def test_whitespace_in_paths(self):
+        result = parameterize_path('/foo/:bar ')
+        self.assertEqual(result, '/foo/(?P<bar>[^\/]+)')
+        result = parameterize_path('/foo/:bar/baz ')
+        self.assertEqual(result, '/foo/(?P<bar>[^\/]+)/baz')


### PR DESCRIPTION
This PR removes all whitespace at the end of an API endpoint. This was causing `404` errors when making requests because the tornado handlers were being registered with spaces.