### PR TITLE
[Issue 48]: Added the optional /api/source endpoint to download the notebook source in http mode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ The app launches kernels in its local process/filesystem space. Can be container
 * Option to prepopulate kernel memory from a notebook
 * A CLI for launching the kernel gateway: `jupyter kernelgateway OPTIONS`
 * Option to serve annotated notebooks as HTTP endpoints, see [notebook-http](#notebook-http-mode)
+* Option to allow downloading of the notebook source when running notebook-http-mode
 
 Run `jupyter kernelgateway --help-all` after installation to see the full set of options.
 

--- a/kernel_gateway/gatewayapp.py
+++ b/kernel_gateway/gatewayapp.py
@@ -169,12 +169,10 @@ class KernelGatewayApp(JupyterApp):
 
     allow_notebook_download_env = 'KG_ALLOW_NOTEBOOK_DOWNLOAD'
     allow_notebook_download = Bool(config=True,
-                   default_value=False,
-                   allow_none=True,
                    help="Optional API to download the notebook source code in notebook-http mode, defaults to not allow"
     )
     def _allow_notebook_download_default(self):
-        return os.getenv(self.allow_notebook_download_env, False)
+        return os.getenv(self.allow_notebook_download_env, 'False') == 'True'
 
     def _load_notebook(self, uri):
         '''

--- a/kernel_gateway/gatewayapp.py
+++ b/kernel_gateway/gatewayapp.py
@@ -247,7 +247,7 @@ class KernelGatewayApp(JupyterApp):
         if self.api == 'notebook-http':
             #Register the NotebookDownloadHandler if configuration allows
             if self.allow_notebook_download:
-                handlers.append((r'/api/source', NotebookDownloadHandler, {'path': self.seed_uri}))
+                handlers.append((r'/_api/source', NotebookDownloadHandler, {'path': self.seed_uri}))
 
             # discover the notebook endpoints and their implementations
             endpoints = self.kernel_manager.endpoints()

--- a/kernel_gateway/services/notebooks/handlers.py
+++ b/kernel_gateway/services/notebooks/handlers.py
@@ -12,6 +12,7 @@ except ImportError:
 from tornado import gen
 from tornado.concurrent import Future
 from ...mixins import TokenAuthorizationMixin, CORSMixin
+import os
 
 class NotebookAPIHandler(TokenAuthorizationMixin, CORSMixin, tornado.web.RequestHandler):
     kernel_pool = None
@@ -124,3 +125,11 @@ class NotebookAPIHandler(TokenAuthorizationMixin, CORSMixin, tornado.web.Request
 
     def options(self, **kwargs):
         self.finish()
+
+class NotebookDownloadHandler(TokenAuthorizationMixin, CORSMixin, tornado.web.StaticFileHandler):
+    def initialize(self, path):
+        self.dirname, self.filename = os.path.split(path)
+        super(NotebookDownloadHandler, self).initialize(self.dirname)
+
+    def get(self, include_body=True):
+        super(NotebookDownloadHandler, self).get(self.filename, include_body)

--- a/kernel_gateway/tests/test_gatewayapp.py
+++ b/kernel_gateway/tests/test_gatewayapp.py
@@ -44,6 +44,7 @@ class TestGatewayAppConfig(unittest.TestCase):
         os.environ['KG_PRESPAWN_COUNT'] = '1'
         os.environ['KG_DEFAULT_KERNEL_NAME'] = 'fake_kernel'
         os.environ['KG_LIST_KERNELS'] = 'True'
+        os.environ['KG_ALLOW_NOTEBOOK_DOWNLOAD'] = 'True'
 
         app = KernelGatewayApp()
 
@@ -62,6 +63,7 @@ class TestGatewayAppConfig(unittest.TestCase):
         self.assertEqual(app.prespawn_count, 1)
         self.assertEqual(app.default_kernel_name, 'fake_kernel')
         self.assertEqual(app.list_kernels, True)
+        self.assertEqual(app.allow_notebook_download, True)
 
 class TestGatewayAppBase(AsyncHTTPTestCase, LogTrapTestCase):
     def tearDown(self):

--- a/kernel_gateway/tests/test_gatewayapp.py
+++ b/kernel_gateway/tests/test_gatewayapp.py
@@ -525,6 +525,45 @@ class TestSeedGatewayApp(TestGatewayAppBase):
 
         ws.close()
 
+class TestDownloadNotebookSource(TestGatewayAppBase):
+    def setup_app(self):
+        self.app.api = 'notebook-http'
+        self.app.seed_uri = os.path.join(RESOURCES,
+                                         'zen{}.ipynb'.format(sys.version_info.major))
+        self.app.allow_notebook_download = True
+
+    @gen_test
+    def test_download_notebook_source(self):
+        '''
+        Notebook source should exists under the path /api/source
+        when allow_notebook download is True
+        '''
+        response = yield self.http_client.fetch(
+            self.get_url('/api/source'),
+            method='GET',
+            raise_error=False
+        )
+        self.assertEqual(response.code, 200, "/api/source did not correctly return the downloaded notebook")
+
+class TestBlockedDownloadNotebookSource(TestGatewayAppBase):
+    def setup_app(self):
+        self.app.api = 'notebook-http'
+        self.app.seed_uri = os.path.join(RESOURCES,
+                                         'zen{}.ipynb'.format(sys.version_info.major))
+    @gen_test
+    def test_blocked_download_notebook_source(self):
+        '''
+        Notebook source should not exist under the path /api/source
+        when allow_notebook download is False or not configured
+        '''
+        response = yield self.http_client.fetch(
+            self.get_url('/api/source'),
+            method='GET',
+            raise_error=False
+        )
+        self.assertEqual(response.code, 301, "/api/source did not block as allow_notebook_download is false")
+
+
 class TestSeedGatewayAppKernelLanguageSupport(TestGatewayAppBase):
     def setup_app(self):
         self.app.prespawn_count = 1

--- a/kernel_gateway/tests/test_gatewayapp.py
+++ b/kernel_gateway/tests/test_gatewayapp.py
@@ -537,15 +537,15 @@ class TestDownloadNotebookSource(TestGatewayAppBase):
     @gen_test
     def test_download_notebook_source(self):
         '''
-        Notebook source should exists under the path /api/source
+        Notebook source should exists under the path /_api/source
         when allow_notebook download is True
         '''
         response = yield self.http_client.fetch(
-            self.get_url('/api/source'),
+            self.get_url('/_api/source'),
             method='GET',
             raise_error=False
         )
-        self.assertEqual(response.code, 200, "/api/source did not correctly return the downloaded notebook")
+        self.assertEqual(response.code, 200, "/_api/source did not correctly return the downloaded notebook")
 
 class TestBlockedDownloadNotebookSource(TestGatewayAppBase):
     def setup_app(self):
@@ -555,15 +555,15 @@ class TestBlockedDownloadNotebookSource(TestGatewayAppBase):
     @gen_test
     def test_blocked_download_notebook_source(self):
         '''
-        Notebook source should not exist under the path /api/source
+        Notebook source should not exist under the path /_api/source
         when allow_notebook download is False or not configured
         '''
         response = yield self.http_client.fetch(
-            self.get_url('/api/source'),
+            self.get_url('/_api/source'),
             method='GET',
             raise_error=False
         )
-        self.assertEqual(response.code, 301, "/api/source did not block as allow_notebook_download is false")
+        self.assertEqual(response.code, 301, "/_api/source did not block as allow_notebook_download is false")
 
 
 class TestSeedGatewayAppKernelLanguageSupport(TestGatewayAppBase):


### PR DESCRIPTION
(c) Copyright IBM Corp. 2015