### PR TITLE
Fix Case When Tests Have Empty Handlers

### DIFF
--- a/kernel_gateway/gatewayapp.py
+++ b/kernel_gateway/gatewayapp.py
@@ -251,6 +251,9 @@ class KernelGatewayApp(JupyterApp):
 
             # discover the notebook endpoints and their implementations
             endpoints = self.kernel_manager.endpoints()
+            if len(endpoints) == 0:
+                raise RuntimeError('No endpoints were discovered. Check your notebook to make sure your cells are annotated correctly.')
+
             sorted_endpoints = self.kernel_manager.sorted_endpoints()
             # append tuples for the notebook's API endpoints
             for uri in sorted_endpoints:

--- a/kernel_gateway/tests/test_gatewayapp.py
+++ b/kernel_gateway/tests/test_gatewayapp.py
@@ -531,7 +531,7 @@ class TestDownloadNotebookSource(TestGatewayAppBase):
     def setup_app(self):
         self.app.api = 'notebook-http'
         self.app.seed_uri = os.path.join(RESOURCES,
-                                         'zen{}.ipynb'.format(sys.version_info.major))
+                                         'kernel_api{}.ipynb'.format(sys.version_info.major))
         self.app.allow_notebook_download = True
 
     @gen_test
@@ -551,7 +551,7 @@ class TestBlockedDownloadNotebookSource(TestGatewayAppBase):
     def setup_app(self):
         self.app.api = 'notebook-http'
         self.app.seed_uri = os.path.join(RESOURCES,
-                                         'zen{}.ipynb'.format(sys.version_info.major))
+                                         'kernel_api{}.ipynb'.format(sys.version_info.major))
     @gen_test
     def test_blocked_download_notebook_source(self):
         '''
@@ -563,7 +563,7 @@ class TestBlockedDownloadNotebookSource(TestGatewayAppBase):
             method='GET',
             raise_error=False
         )
-        self.assertEqual(response.code, 301, "/_api/source did not block as allow_notebook_download is false")
+        self.assertEqual(response.code, 404, "/_api/source did not block as allow_notebook_download is false")
 
 
 class TestSeedGatewayAppKernelLanguageSupport(TestGatewayAppBase):


### PR DESCRIPTION
Fixed source download tests to use a notebook with http endpoints.
Also updated main app to throw runtime error when there are no handlers registered.
(c) Copyright IBM Corp. 2015