### PR TITLE
[issue: 71] In jupyter-websocket mode, base handler tries to use jinja to render an error

### DIFF
--- a/kernel_gateway/services/kernels/handlers.py
+++ b/kernel_gateway/services/kernels/handlers.py
@@ -3,6 +3,7 @@
 
 import tornado
 import notebook.services.kernels.handlers as notebook_handlers
+from notebook.base.handlers import IPythonHandler
 from ...mixins import TokenAuthorizationMixin, CORSMixin
 
 class MainKernelHandler(TokenAuthorizationMixin, 
@@ -43,6 +44,9 @@ class MainKernelHandler(TokenAuthorizationMixin,
             else:
                 model.setdefault('name', self.settings['kg_default_kernel_name'])
         return model
+
+    def write_error(self, status_code, **kwargs):
+        super(IPythonHandler, self).write_error(status_code, **kwargs)
 
 default_handlers = []
 for path, cls in notebook_handlers.default_handlers:


### PR DESCRIPTION
Avoid the jinja usage in our kernel handler by writing errors through the base
tornado handler.
(c) Copyright IBM Corp. 2016