### PR TITLE
Added CORS and Token Authorization to swagger spec handler.

### DIFF
--- a/kernel_gateway/services/swagger/handlers.py
+++ b/kernel_gateway/services/swagger/handlers.py
@@ -4,8 +4,9 @@
 import tornado.web
 import json
 from .builders import *
+from ...mixins import TokenAuthorizationMixin, CORSMixin
 
-class SwaggerSpecHandler(tornado.web.RequestHandler):
+class SwaggerSpecHandler(TokenAuthorizationMixin, CORSMixin, tornado.web.RequestHandler):
     '''A tornado handler to serve requests for a swagger specification.
     Given a collection of cell sources, notebook title and kernel name, this
     handler will generate a swagger specification describing the API.


### PR DESCRIPTION
This pull request adds the CORS and TokenAuthorization mixins to the swagger spec handler. This allows for sites like http://petstore.swagger.io to consume the spec. It will also allow a layer of protection via token authorization in the event the swagger spec should not be publicly available.