### PR TITLE
Set allow_origin for check_origin

### DIFF
--- a/kernel_gateway/gatewayapp.py
+++ b/kernel_gateway/gatewayapp.py
@@ -310,7 +310,10 @@ class KernelGatewayApp(JupyterApp):
             kg_max_age=self.max_age,
             kg_max_kernels=self.max_kernels,
             kg_list_kernels=self.list_kernels,
-            kg_api=self.api
+            kg_api=self.api,
+            # Also set the allow_origin setting used by notebook so that the
+            # check_origin method used everywhere respects the value
+            allow_origin=self.allow_origin
         )
 
     def init_http_server(self):

--- a/kernel_gateway/tests/test_gatewayapp.py
+++ b/kernel_gateway/tests/test_gatewayapp.py
@@ -137,6 +137,28 @@ class TestGatewayApp(TestGatewayAppBase):
         self.assertEqual(response.code, 404)
 
     @gen_test
+    def test_check_origin(self):
+        '''Allow origin setting should pass through to base handlers.'''
+        response = yield self.http_client.fetch(
+            self.get_url('/api/kernelspecs'),
+            method='GET',
+            headers={'Origin': 'fake.com:8888'},
+            raise_error=False
+        )
+        self.assertEqual(response.code, 404)
+
+        app = self.get_app()
+        app.settings['allow_origin'] = '*'
+
+        response = yield self.http_client.fetch(
+            self.get_url('/api/kernelspecs'),
+            method='GET',
+            headers={'Origin': 'fake.com:8888'},
+            raise_error=False
+        )
+        self.assertEqual(response.code, 200)
+
+    @gen_test
     def test_config_bad_api_value(self):
         '''A ValueError should be raised on an unsupported KernelGatewayApp.api value'''
         def _set_api():


### PR DESCRIPTION
`check_origin` in the notebook base handlers acts as a lightweight auth mechanism for websocket connections (which don't support CORS). Setting allow_origin to '*' disables this check, which is desirable in the case where clients are not browsers and token auth is enabled. Unfortunately, we're not passing the kg_allow_origin prefixed setting through as allow_origin because we wanted to avoid conflicts. So check_origin is griping for remote clients when the Origin / Host headers are specified.

We should pass the kg_allow_origin value through to the Tornado settings as allow_origin as well.