### PR TITLE
Ensure base path is prefixed with forward slash.

### DIFF
--- a/kernel_gateway/gatewayapp.py
+++ b/kernel_gateway/gatewayapp.py
@@ -291,7 +291,7 @@ class KernelGatewayApp(JupyterApp):
                 default_base_handlers
             ):
                 # Create a new handler pattern rooted at the base_url
-                pattern = url_path_join(self.base_url, handler[0])
+                pattern = url_path_join('/', self.base_url, handler[0])
                 # Some handlers take args, so retain those in addition to the
                 # handler class ref
                 new_handler = tuple([pattern] + list(handler[1:]))

--- a/kernel_gateway/tests/test_gatewayapp.py
+++ b/kernel_gateway/tests/test_gatewayapp.py
@@ -523,6 +523,22 @@ class TestRelocatedGatewayApp(TestGatewayAppBase):
         )
         self.assertEqual(response.code, 200)
 
+class TestFixBaseUrlGatewayApp(TestGatewayAppBase):
+    def setup_app(self):
+        self.app.base_url = 'fake/path'
+
+    @gen_test
+    def test_base_url(self):
+        '''Server should mount resources under fixed base.'''
+        self.app.web_app.settings['kg_list_kernels'] = True
+
+        # Should exist under path
+        response = yield self.http_client.fetch(
+            self.get_url('/fake/path/api/kernels'),
+            method='GET'
+        )
+        self.assertEqual(response.code, 200)
+
 class TestSeedGatewayApp(TestGatewayAppBase):
     def setup_app(self):
         self.app.seed_uri = os.path.join(RESOURCES,


### PR DESCRIPTION
Fix case where base path/url is missing leading slash.