### PR TITLE
[issue: 79] Filter stderr

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,5 @@ docs/_build/
 
 # PyBuilder
 target/
+
+.DS_Store

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,12 @@ dev:
 	@$(DOCKER) -p 8888:8888 $(IMAGE) \
 		python $(PYARGS) kernel_gateway --KernelGatewayApp.ip='0.0.0.0' $(ARGS)
 
+etc/api_examples/%:
+	$(DOCKER) -p 8888:8888 $(IMAGE) \
+		python $(PYARGS) kernel_gateway --KernelGatewayApp.ip='0.0.0.0' \
+			--KernelGatewayApp.api='notebook-http' \
+			--KernelGatewayApp.seed_uri=/srv/kernel_gateway/$@.ipynb $(ARGS)
+
 install:
 	$(DOCKER) $(IMAGE) bash -c "pip install dist/*.whl && \
 		jupyter kernelgateway --help && \

--- a/etc/api_examples/api_intro.ipynb
+++ b/etc/api_examples/api_intro.ipynb
@@ -317,6 +317,30 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import sys"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# GET /stderr\n",
+    "print('I am text on stdout')\n",
+    "print('I am text on stderr', file=sys.stderr)"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -368,7 +392,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.4.3"
+   "version": "3.4.4"
   }
  },
  "nbformat": 4,

--- a/kernel_gateway/gatewayapp.py
+++ b/kernel_gateway/gatewayapp.py
@@ -2,6 +2,7 @@
 # Distributed under the terms of the Modified BSD License.
 
 import os
+import logging
 import nbformat
 
 try:
@@ -296,6 +297,9 @@ class KernelGatewayApp(JupyterApp):
                 # handler class ref
                 new_handler = tuple([pattern] + list(handler[1:]))
                 handlers.append(new_handler)
+
+        # Configure the tornado logging level too
+        logging.getLogger().setLevel(self.log_level)
 
         self.web_app = web.Application(
             handlers=handlers,

--- a/kernel_gateway/tests/resources/kernel_api2.ipynb
+++ b/kernel_gateway/tests/resources/kernel_api2.ipynb
@@ -10,8 +10,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "import json"
@@ -19,8 +21,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "hello_message = 'hello {}'\n",
@@ -36,8 +40,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# GET /hello\n",
@@ -46,8 +52,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "REQUEST = json.dumps({\n",
@@ -59,8 +67,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# GET /hello/person\n",
@@ -71,8 +81,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "REQUEST = json.dumps({\n",
@@ -84,8 +96,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# GET /hello/persons\n",
@@ -96,8 +110,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# GET /hello/people\n",
@@ -107,8 +123,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "REQUEST = json.dumps({\n",
@@ -120,8 +138,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# GET /hello/:person\n",
@@ -138,8 +158,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# GET /message\n",
@@ -148,8 +170,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "REQUEST = json.dumps({\n",
@@ -159,8 +183,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# PUT /message\n",
@@ -178,8 +204,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# GET /people\n",
@@ -188,8 +216,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "REQUEST = json.dumps({\n",
@@ -199,8 +229,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# POST /people\n",
@@ -211,8 +243,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "REQUEST = json.dumps({\n",
@@ -222,8 +256,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# PUT /people\n",
@@ -234,8 +270,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "REQUEST = json.dumps({\n",
@@ -247,8 +285,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# DELETE /people/:index\n",
@@ -259,8 +299,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# GET /sleep/:time\n",
@@ -280,8 +322,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# GET /error\n",
@@ -290,8 +334,34 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import sys"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# GET /stderr\n",
+    "print 'I am text on stdout'\n",
+    "print >> sys.stderr, 'I am text on stderr'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# GET /content-type\n",
@@ -309,14 +379,14 @@
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3.0
+    "version": 2
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "2.7.10"
+   "pygments_lexer": "ipython2",
+   "version": "2.7.11"
   }
  },
  "nbformat": 4,

--- a/kernel_gateway/tests/resources/kernel_api3.ipynb
+++ b/kernel_gateway/tests/resources/kernel_api3.ipynb
@@ -10,8 +10,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "import json"
@@ -19,8 +21,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "hello_message = 'hello {}'\n",
@@ -36,8 +40,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# GET /hello\n",
@@ -46,8 +52,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "REQUEST = json.dumps({\n",
@@ -59,8 +67,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# GET /hello/person\n",
@@ -71,8 +81,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "REQUEST = json.dumps({\n",
@@ -84,8 +96,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# GET /hello/persons\n",
@@ -96,8 +110,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# GET /hello/people\n",
@@ -107,8 +123,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "REQUEST = json.dumps({\n",
@@ -120,8 +138,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# GET /hello/:person\n",
@@ -138,8 +158,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# GET /message\n",
@@ -148,8 +170,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "REQUEST = json.dumps({\n",
@@ -159,8 +183,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# PUT /message\n",
@@ -178,8 +204,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# GET /people\n",
@@ -188,8 +216,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "REQUEST = json.dumps({\n",
@@ -199,8 +229,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# POST /people\n",
@@ -211,8 +243,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "REQUEST = json.dumps({\n",
@@ -222,8 +256,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# PUT /people\n",
@@ -234,8 +270,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "REQUEST = json.dumps({\n",
@@ -247,8 +285,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# DELETE /people/:index\n",
@@ -259,8 +299,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# GET /sleep/:time\n",
@@ -280,8 +322,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# GET /error\n",
@@ -290,8 +334,34 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import sys"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# GET /stderr\n",
+    "print('I am text on stdout')\n",
+    "print('I am text on stderr', file=sys.stderr)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# GET /content-type\n",
@@ -309,14 +379,14 @@
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3.0
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.4.3"
+   "version": "3.4.4"
   }
  },
  "nbformat": 4,

--- a/kernel_gateway/tests/test_gatewayapp.py
+++ b/kernel_gateway/tests/test_gatewayapp.py
@@ -849,6 +849,16 @@ class TestAPIGatewayApp(TestGatewayAppBase):
         self.assertEqual(response.code, 500, 'Cell with error did not return 500 status code.')
 
     @gen_test
+    def test_api_stderr_endpoint(self):
+        '''stderr output in a cell should be dropped'''
+        response = yield self.http_client.fetch(
+            self.get_url('/stderr'),
+            method='GET',
+            raise_error=False
+        )
+        self.assertEqual(response.body, b'I am text on stdout\n', 'Unexpected text in response')
+
+    @gen_test
     def test_api_unsupported_method(self):
         '''Endpoints which are not registered should return 404 HTTP status
         '''


### PR DESCRIPTION
Fixes #79. Ignores everything except stdout if the kernel conforms to the messaging spec and incluedes a content.name attribute (http://jupyter-client.readthedocs.org/en/latest/messaging.html#streams-stdout-stderr-etc). If no stream name is provided, forwards arbitrary content because it's unknown whether the output was on stdout or not. 