### PR TITLE
[issue #99] Use JSON bodies for all errors

### DIFF
--- a/kernel_gateway/base/handlers.py
+++ b/kernel_gateway/base/handlers.py
@@ -1,14 +1,22 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
+from tornado import web
 import notebook.base.handlers as notebook_handlers
-from ..mixins import TokenAuthorizationMixin, CORSMixin
+from ..mixins import TokenAuthorizationMixin, CORSMixin, JSONErrorsMixin
 
-class APIVersionHandler(TokenAuthorizationMixin, 
-                        CORSMixin, 
+class APIVersionHandler(TokenAuthorizationMixin,
+                        CORSMixin,
+                        JSONErrorsMixin,
                         notebook_handlers.APIVersionHandler):
     pass
 
+class NotFoundHandler(JSONErrorsMixin, web.RequestHandler):
+    '''Catches all requests and respondes with 404 JSON messages.'''
+    def prepare(self):
+        raise web.HTTPError(404)
+
 default_handlers = [
-    (r"/api", APIVersionHandler)
+    (r'/api', APIVersionHandler),
+    (r'/(.*)', NotFoundHandler)
 ]

--- a/kernel_gateway/mixins.py
+++ b/kernel_gateway/mixins.py
@@ -1,6 +1,13 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
+import json
+try:
+    # py3
+    from http.client import responses
+except ImportError:
+    from httplib import responses
+
 class CORSMixin(object):
     '''
     Adds CORS headers to tornado.web.RequestHandlers.
@@ -31,7 +38,7 @@ class CORSMixin(object):
 
 class TokenAuthorizationMixin(object):
     '''
-    Adds token authentication to tornado.web.RequestHandlers and 
+    Adds token authentication to tornado.web.RequestHandlers and
     tornado.websocket.WebsocketHandlers.
     '''
     def prepare(self):
@@ -46,3 +53,37 @@ class TokenAuthorizationMixin(object):
             if client_token != 'token %s' % server_token:
                 return self.send_error(401)
         return super(TokenAuthorizationMixin, self).prepare()
+
+class JSONErrorsMixin(object):
+    '''
+    Outputs all errors as JSON in the same format as the
+    notebook.base.handlers.json_errors decorator. Avoids having to (re-)decorate
+    everything that the kernel gateway overrides. Also avoids rendering errors
+    as a human readable HTML pages in cases where the decorator is not used
+    in the notebook code base.
+    '''
+    def write_error(self, status_code, **kwargs):
+        '''
+        Overrides the HTML renderer in the notebook server to force all errors
+        to JSON format.
+        '''
+        exc_info = kwargs.get('exc_info')
+        message = ''
+        reason = responses.get(status_code, 'Unknown HTTP Error')
+        if exc_info:
+            exception = exc_info[1]
+            # Get the custom message, if defined
+            try:
+                message = exception.log_message % exception.args
+            except Exception:
+                pass
+
+            # Construct the custom reason, if defined
+            custom_reason = getattr(exception, 'reason', '')
+            if custom_reason:
+                reason = custom_reason
+
+        self.set_header('Content-Type', 'application/json')
+        self.set_status(status_code)
+        reply = dict(reason=reason, message=message)
+        self.finish(json.dumps(reply))

--- a/kernel_gateway/services/activity/handlers.py
+++ b/kernel_gateway/services/activity/handlers.py
@@ -4,9 +4,12 @@
 import tornado.web
 import json
 from .manager import activity
-from ...mixins import TokenAuthorizationMixin, CORSMixin
+from ...mixins import TokenAuthorizationMixin, CORSMixin, JSONErrorsMixin
 
-class ActivityHandler(TokenAuthorizationMixin, CORSMixin, tornado.web.RequestHandler):
+class ActivityHandler(TokenAuthorizationMixin,
+                      CORSMixin,
+                      JSONErrorsMixin,
+                      tornado.web.RequestHandler):
 
     def get(self, **kwargs):
         if not self.settings.get('kg_list_kernels'):

--- a/kernel_gateway/services/kernels/handlers.py
+++ b/kernel_gateway/services/kernels/handlers.py
@@ -1,18 +1,17 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
+import json
 import tornado
-from notebook.base.handlers import json_errors
 import notebook.services.kernels.handlers as notebook_handlers
-from ...mixins import TokenAuthorizationMixin, CORSMixin
+from ...mixins import TokenAuthorizationMixin, CORSMixin, JSONErrorsMixin
 from ...services.activity.manager import activity, LAST_MESSAGE_TO_CLIENT, LAST_MESSAGE_TO_KERNEL, LAST_TIME_STATE_CHANGED, BUSY, CONNECTIONS, LAST_CLIENT_CONNECT, LAST_CLIENT_DISCONNECT
 from datetime import datetime
-import json
 
 class MainKernelHandler(TokenAuthorizationMixin,
                         CORSMixin,
+                        JSONErrorsMixin,
                         notebook_handlers.MainKernelHandler):
-    @json_errors
     def post(self):
         '''
         Honors the max number of allowed kernels configuration setting. Raises
@@ -27,7 +26,6 @@ class MainKernelHandler(TokenAuthorizationMixin,
 
         super(MainKernelHandler, self).post()
 
-    @json_errors
     def get(self):
         '''
         Denies returning a list of running kernels unless explicitly
@@ -56,17 +54,17 @@ class MainKernelHandler(TokenAuthorizationMixin,
 
 class KernelHandler(TokenAuthorizationMixin,
                     CORSMixin,
+                    JSONErrorsMixin,
                     notebook_handlers.KernelHandler):
     '''This class will remove a kernel from the activity store when it is delted.
     '''
-    @json_errors
     def delete(self, kernel_id):
         if self.settings.get('kg_list_kernels'):
             activity.remove(kernel_id)
         super(KernelHandler, self).delete(kernel_id)
 
 class ZMQChannelsHandler(TokenAuthorizationMixin,
-                        notebook_handlers.ZMQChannelsHandler):
+                         notebook_handlers.ZMQChannelsHandler):
     '''This class listens for messages coming to and from the kernel to provide metrics
     about kernel usage.
     '''

--- a/kernel_gateway/services/kernelspecs/handlers.py
+++ b/kernel_gateway/services/kernelspecs/handlers.py
@@ -2,10 +2,10 @@
 # Distributed under the terms of the Modified BSD License.
 
 import notebook.services.kernelspecs.handlers as notebook_handlers
-from ...mixins import TokenAuthorizationMixin, CORSMixin
+from ...mixins import TokenAuthorizationMixin, CORSMixin, JSONErrorsMixin
 
 default_handlers = []
 for path, cls in notebook_handlers.default_handlers:
     # Everything should have CORS and token auth
-    bases = (TokenAuthorizationMixin, CORSMixin, cls)
+    bases = (TokenAuthorizationMixin, CORSMixin, JSONErrorsMixin, cls)
     default_handlers.append((path, type(cls.__name__, bases, {})))

--- a/kernel_gateway/services/notebooks/handlers.py
+++ b/kernel_gateway/services/notebooks/handlers.py
@@ -8,12 +8,15 @@ from .request_utils import (parse_body, parse_args, format_request,
 
 from tornado import gen
 from tornado.concurrent import Future
-from ...mixins import TokenAuthorizationMixin, CORSMixin
+from ...mixins import TokenAuthorizationMixin, CORSMixin, JSONErrorsMixin
 from functools import partial
-from .errors import UnsupportedMethodError,CodeExecutionError
+from .errors import UnsupportedMethodError, CodeExecutionError
 import os
 
-class NotebookAPIHandler(TokenAuthorizationMixin, CORSMixin, tornado.web.RequestHandler):
+class NotebookAPIHandler(TokenAuthorizationMixin,
+                         CORSMixin,
+                         JSONErrorsMixin,
+                         tornado.web.RequestHandler):
     '''Executes annotated notebook cells in response to associated HTTP requests.'''
 
     def initialize(self, sources, response_sources, kernel_pool, kernel_name):
@@ -159,7 +162,10 @@ class NotebookAPIHandler(TokenAuthorizationMixin, CORSMixin, tornado.web.Request
     def options(self, **kwargs):
         self.finish()
 
-class NotebookDownloadHandler(TokenAuthorizationMixin, CORSMixin, tornado.web.StaticFileHandler):
+class NotebookDownloadHandler(TokenAuthorizationMixin,
+                              CORSMixin,
+                              JSONErrorsMixin,
+                              tornado.web.StaticFileHandler):
     '''Allows clients to download the original notebook behind the HTTP facade.'''
     def initialize(self, path):
         self.dirname, self.filename = os.path.split(path)

--- a/kernel_gateway/services/sessions/handlers.py
+++ b/kernel_gateway/services/sessions/handlers.py
@@ -2,18 +2,17 @@
 # Distributed under the terms of the Modified BSD License.
 
 import tornado
-from notebook.base.handlers import json_errors
 import notebook.services.sessions.handlers as notebook_handlers
-from ...mixins import TokenAuthorizationMixin, CORSMixin
+from ...mixins import TokenAuthorizationMixin, CORSMixin, JSONErrorsMixin
 
-class SessionRootHandler(TokenAuthorizationMixin, 
-                        CORSMixin, 
+class SessionRootHandler(TokenAuthorizationMixin,
+                        CORSMixin,
+                        JSONErrorsMixin,
                         notebook_handlers.SessionRootHandler):
-    @json_errors
     def get(self):
         '''
         Denies returning a list of running sessions  unless explicitly
-        enabled, instead returning a 403 error indicating that the list is 
+        enabled, instead returning a 403 error indicating that the list is
         permanently forbidden.
         '''
         if 'kg_list_kernels' not in self.settings or self.settings['kg_list_kernels'] != True:

--- a/kernel_gateway/services/swagger/handlers.py
+++ b/kernel_gateway/services/swagger/handlers.py
@@ -4,9 +4,12 @@
 import tornado.web
 import json
 from .builders import *
-from ...mixins import TokenAuthorizationMixin, CORSMixin
+from ...mixins import TokenAuthorizationMixin, CORSMixin, JSONErrorsMixin
 
-class SwaggerSpecHandler(TokenAuthorizationMixin, CORSMixin, tornado.web.RequestHandler):
+class SwaggerSpecHandler(TokenAuthorizationMixin,
+                         CORSMixin,
+                         JSONErrorsMixin,
+                         tornado.web.RequestHandler):
     '''A tornado handler to serve requests for a swagger specification.
     Given a collection of cell sources, notebook title and kernel name, this
     handler will generate a swagger specification describing the API.

--- a/kernel_gateway/tests/test_jupyter_websocket.py
+++ b/kernel_gateway/tests/test_jupyter_websocket.py
@@ -357,6 +357,7 @@ class TestDefaults(TestJupyterWebsocket):
             raise_error=False
         )
         self.assertEqual(response.code, 403)
+
         response = yield self.http_client.fetch(
             self.get_url('/api/sessions'),
             raise_error=False
@@ -433,6 +434,14 @@ class TestDefaults(TestJupyterWebsocket):
         # self.assertEqual(body['reason'], 'Not Found')
         self.assertIn('1-2-3-4-5', body['message'])
 
+        # The last resort not found handler
+        response = yield self.http_client.fetch(
+            self.get_url('/fake-endpoint'),
+            raise_error=False
+        )
+        body = json_decode(response.body)
+        self.assertEqual(response.code, 404)
+        self.assertEqual(body['reason'], 'Not Found')
 
 class TestEnableDiscovery(TestJupyterWebsocket):
     def setup_app(self):

--- a/kernel_gateway/tests/test_jupyter_websocket.py
+++ b/kernel_gateway/tests/test_jupyter_websocket.py
@@ -410,6 +410,29 @@ class TestDefaults(TestJupyterWebsocket):
         sessions = json_decode(response.body)
         self.assertEqual(len(sessions), 0)
 
+    @gen_test
+    def test_json_errors(self):
+        '''Handlers should always return JSON errors.'''
+        # A handler that we override
+        response = yield self.http_client.fetch(
+            self.get_url('/api/kernels'),
+            raise_error=False
+        )
+        body = json_decode(response.body)
+        self.assertEqual(response.code, 403)
+        self.assertEqual(body['reason'], 'Forbidden')
+
+        # A handler from the notebook base
+        response = yield self.http_client.fetch(
+            self.get_url('/api/kernels/1-2-3-4-5'),
+            raise_error=False
+        )
+        body = json_decode(response.body)
+        self.assertEqual(response.code, 404)
+        # Base handler json_errors decorator does not capture reason properly
+        # self.assertEqual(body['reason'], 'Not Found')
+        self.assertIn('1-2-3-4-5', body['message'])
+
 
 class TestEnableDiscovery(TestJupyterWebsocket):
     def setup_app(self):

--- a/kernel_gateway/tests/test_mixins.py
+++ b/kernel_gateway/tests/test_mixins.py
@@ -1,0 +1,54 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+import json
+import unittest
+from tornado import web
+from kernel_gateway.mixins import JSONErrorsMixin
+
+class TestableHandler(JSONErrorsMixin):
+    def __init__(self):
+        self.headers = {}
+        self.response = None
+        self.status_code = None
+
+    def finish(self, response):
+        self.response = response
+
+    def set_status(self, status_code):
+        self.status_code = status_code
+
+    def set_header(self, name, value):
+        self.headers[name] = value
+
+class TestJSONErrorsMixin(unittest.TestCase):
+    def setUp(self):
+        self.mixin = TestableHandler()
+
+    def test_status(self):
+        '''Status should be set on the response.'''
+        self.mixin.write_error(404)
+        response = json.loads(self.mixin.response)
+        self.assertEqual(self.mixin.status_code, 404)
+        self.assertEqual(response['reason'], 'Not Found')
+        self.assertEqual(response['message'], '')
+
+    def test_custom_status(self):
+        '''Custom reason from exeception should be set in the response.'''
+        exc = web.HTTPError(500, reason='fake-reason')
+        self.mixin.write_error(500, exc_info=[None, exc])
+
+        response = json.loads(self.mixin.response)
+        self.assertEqual(self.mixin.status_code, 500)
+        self.assertEqual(response['reason'], 'fake-reason')
+        self.assertEqual(response['message'], '')
+
+    def test_log_message(self):
+        '''Custom message from exeception should be set in the response.'''
+        exc = web.HTTPError(410, log_message='fake-message')
+        self.mixin.write_error(410, exc_info=[None, exc])
+
+        response = json.loads(self.mixin.response)
+        self.assertEqual(self.mixin.status_code, 410)
+        self.assertEqual(response['reason'], 'Gone')
+        self.assertEqual(response['message'], 'fake-message')

--- a/kernel_gateway/tests/test_notebook_http.py
+++ b/kernel_gateway/tests/test_notebook_http.py
@@ -146,14 +146,16 @@ class TestDefaults(TestGatewayAppBase):
     @gen_test
     def test_api_undefined(self):
         '''
-        Endpoints which are not registered at all should be 404s
+        Endpoints which are not registered at all should be 404s with JSON bodies.
         '''
         response = yield self.http_client.fetch(
             self.get_url('/not/an/endpoint'),
             method='GET',
             raise_error=False
         )
+        body = json.loads(response.body.decode('UTF-8'))
         self.assertEqual(response.code, 404, 'Endpoint which should not exist did not return 404 status code.')
+        self.assertEqual(body['reason'], 'Not Found')
 
     @gen_test
     def test_api_access_http_header(self):


### PR DESCRIPTION
Make sure every handler responds with a consistent JSON body on error. Avoid any invocation of jinja for error template rendering.

* Remove spurious use of @json_errors decorator
* Add a mixin that works everywhere
* Add a last resort `/(.*)` route that returns a 404 with JSON body
* Tests

Fixes #99 